### PR TITLE
DRE-1762 Update honeymarker installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.2-buster
+FROM golang:1.19-buster
 
 LABEL "com.github.actions.name"="Honeycomb Honeymarker Github Actions"
 LABEL "com.github.actions.description"="Add Honeycomb Markers to your GitHub Actions workflows."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 function install_binary() {
-    go get github.com/honeycombio/honeymarker
+    go install github.com/honeycombio/honeymarker
 }
 
 function create_marker() {


### PR DESCRIPTION
Old versions of golang were starting to generate errors during
installation.
